### PR TITLE
Add descending sorting in fetch data by end date

### DIFF
--- a/src/shared/fetch-data.js
+++ b/src/shared/fetch-data.js
@@ -1,5 +1,10 @@
 const cache = {};
 
+const formatDate = (item) => {
+  if (item.is_current) return new Date();
+  return new Date(item.end_date || item.date_to);
+};
+
 export const fetchData = (username) => {
   if (cache[username]) return Promise.resolve(cache[username]);
 
@@ -11,8 +16,14 @@ export const fetchData = (username) => {
   })
     .then((res) => res.json())
     .then((data) => {
-      cache[username] = data.projects || [];
-      return data.projects || [];
+      const sortedProjects = data.projects || [];
+      sortedProjects.sort((p1, p2) => {
+        const p1endDate = formatDate(p1);
+        const p2endDate = formatDate(p2);
+        return p2endDate - p1endDate;
+      });
+      cache[username] = sortedProjects;
+      return sortedProjects;
     })
     .catch((err) => {
       // eslint-disable-next-line


### PR DESCRIPTION
Currently, the projects are not sorted by date, rather by insertion time (most probably, guessed). Most of the time people want to showcase the latest projects on top.

In this PR, after fetching data from the API, the projects will be sorted by `end_date` or `date_to`. 